### PR TITLE
Update css-flexbox-tests.txt for new/deleted tests

### DIFF
--- a/compat-2021/css-flexbox-tests.txt
+++ b/compat-2021/css-flexbox-tests.txt
@@ -168,13 +168,13 @@
 /css/css-flexbox/select-element-zero-height-002.html
 /css/css-flexbox/svg-root-as-flex-item-002.html
 /css/css-flexbox/svg-root-as-flex-item-003.html
-/css/css-flexbox/table-as-item-fixed-min-width-3.html
-/css/css-flexbox/table-as-item-flex-cross-size.html
+# /css/css-flexbox/table-as-item-fixed-min-width-3.html
+# /css/css-flexbox/table-as-item-flex-cross-size.html
 /css/css-flexbox/table-as-item-narrow-content.html
-/css/css-flexbox/table-as-item-specified-width.html
+# /css/css-flexbox/table-as-item-specified-width.html
 /css/css-flexbox/table-as-item-stretch-cross-size.html
-/css/css-flexbox/table-item-flex-percentage-width.html
-/css/css-flexbox/table-with-percent-intrinsic-width.html
+# /css/css-flexbox/table-item-flex-percentage-width.html
+# /css/css-flexbox/table-with-percent-intrinsic-width.html
 /css/css-flexbox/abspos/abspos-autopos-htb-ltr.html
 /css/css-flexbox/abspos/abspos-autopos-htb-rtl.html
 /css/css-flexbox/abspos/abspos-autopos-vlr-ltr.html
@@ -1061,7 +1061,7 @@
 /css/css-flexbox/table-as-item-auto-min-width.html
 /css/css-flexbox/table-as-item-change-cell.html
 /css/css-flexbox/table-as-item-cross-size.html
-/css/css-flexbox/table-as-item-fixed-min-width-2.html
+# /css/css-flexbox/table-as-item-fixed-min-width-2.html
 /css/css-flexbox/table-as-item-fixed-min-width.html
 /css/css-flexbox/table-as-item-wide-content.html
 /css/css-flexbox/table-with-float-paint.html
@@ -1089,8 +1089,8 @@
 /css/css-flexbox/flexbox_justifycontent-right-002.html
 /css/css-flexbox/flexbox_justifycontent-start.html
 /css/css-flexbox/flexbox_justifycontent-start-rtl.html
-/css/css-flexbox/flexbox-min-width-auto-005.html
-/css/css-flexbox/flexbox-min-width-auto-006.html
+# /css/css-flexbox/flexbox-min-width-auto-005.html
+# /css/css-flexbox/flexbox-min-width-auto-006.html
 /css/css-flexbox/flexbox-overflow-padding-001.html
 /css/css-flexbox/flexbox-overflow-padding-002.html
 /css/css-flexbox/flex-minimum-height-flex-items-025.html
@@ -1107,18 +1107,18 @@
 /css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
 /css/css-flexbox/percentage-max-height-004.html
 /css/css-flexbox/percentage-padding-002.html
-/css/css-flexbox/table-as-item-inflexible-in-column-1.html
-/css/css-flexbox/table-as-item-inflexible-in-column-2.html
+# /css/css-flexbox/table-as-item-inflexible-in-column-1.html
+# /css/css-flexbox/table-as-item-inflexible-in-column-2.html
 /css/css-flexbox/table-as-item-inflexible-in-row-1.html
-/css/css-flexbox/table-as-item-inflexible-in-row-2.html
+# /css/css-flexbox/table-as-item-inflexible-in-row-2.html
 /css/css-flexbox/table-as-item-min-content-height-1.tentative.html
 /css/css-flexbox/table-as-item-min-content-height-2.tentative.html
-/css/css-flexbox/table-as-item-min-height-1.html
-/css/css-flexbox/table-as-item-narrow-content-2.html
-/css/css-flexbox/table-as-item-percent-width-cell-001.html
-/css/css-flexbox/table-as-item-specified-height.html
-/css/css-flexbox/table-as-item-stretch-cross-size-2.html
+# /css/css-flexbox/table-as-item-min-height-1.html
+# /css/css-flexbox/table-as-item-narrow-content-2.html
+# /css/css-flexbox/table-as-item-percent-width-cell-001.html
+# /css/css-flexbox/table-as-item-specified-height.html
+# /css/css-flexbox/table-as-item-stretch-cross-size-2.html
 /css/css-flexbox/table-as-item-stretch-cross-size-3.html
 /css/css-flexbox/table-as-item-stretch-cross-size-4.html
-/css/css-flexbox/table-as-item-stretch-cross-size-5.html
+# /css/css-flexbox/table-as-item-stretch-cross-size-5.html
 /css/css-flexbox/table-item-flex-percentage-min-width.html

--- a/compat-2021/css-flexbox-tests.txt
+++ b/compat-2021/css-flexbox-tests.txt
@@ -74,10 +74,6 @@
 /css/css-flexbox/break-nested-float-in-flex-item-002-print.html
 # /css/css-flexbox/canvas-dynamic-change-001.html
 /css/css-flexbox/cross-axis-scrollbar.html
-/css/css-flexbox/css-flexbox-column-reverse-wrap-reverse.html
-/css/css-flexbox/css-flexbox-column-reverse-wrap.html
-/css/css-flexbox/css-flexbox-column-wrap-reverse.html
-/css/css-flexbox/css-flexbox-column-wrap.html
 # /css/css-flexbox/dynamic-baseline-change-nested.html
 # /css/css-flexbox/dynamic-baseline-change.html
 /css/css-flexbox/dynamic-grid-flex-abspos.html
@@ -384,8 +380,6 @@
 /css/css-flexbox/contain-size-layout-abspos-flex-container-crash.html
 /css/css-flexbox/content-height-with-scrollbars.html
 /css/css-flexbox/css-box-justify-content.html
-/css/css-flexbox/css-flexbox-column-reverse.html
-/css/css-flexbox/css-flexbox-column.html
 /css/css-flexbox/css-flexbox-img-expand-evenly.html
 /css/css-flexbox/css-flexbox-row-reverse-wrap-reverse.html
 /css/css-flexbox/css-flexbox-row-reverse-wrap.html
@@ -1075,3 +1069,56 @@
 /css/css-flexbox/text-overflow-on-flexbox-001.html
 /css/css-flexbox/whitespace-in-flexitem-001.html
 /css/css-flexbox/zero-content-size-with-scrollbar-crash.html
+# Added 2021-05-12. Started from
+# git log --name-status --diff-filter=AD --format= --since=2021-01-21 -- . |grep -v ref.html | grep -v \/support\/ | sort
+/css/css-flexbox/aspect-ratio-intrinsic-size-001.html
+/css/css-flexbox/aspect-ratio-intrinsic-size-002.html
+/css/css-flexbox/aspect-ratio-intrinsic-size-003.html
+/css/css-flexbox/aspect-ratio-intrinsic-size-004.html
+/css/css-flexbox/aspect-ratio-intrinsic-size-005.html
+/css/css-flexbox/aspect-ratio-intrinsic-size-006.html
+/css/css-flexbox/canvas-contain-size.html
+/css/css-flexbox/flex-basis-011.html
+/css/css-flexbox/flexbox_align-items-center-3.html
+/css/css-flexbox/flexbox-definite-sizes-006.html
+/css/css-flexbox/flexbox_justifycontent-end.html
+/css/css-flexbox/flexbox_justifycontent-end-rtl.html
+/css/css-flexbox/flexbox_justifycontent-left-001.html
+/css/css-flexbox/flexbox_justifycontent-left-002.html
+/css/css-flexbox/flexbox_justifycontent-right-001.html
+/css/css-flexbox/flexbox_justifycontent-right-002.html
+/css/css-flexbox/flexbox_justifycontent-start.html
+/css/css-flexbox/flexbox_justifycontent-start-rtl.html
+/css/css-flexbox/flexbox-min-width-auto-005.html
+/css/css-flexbox/flexbox-min-width-auto-006.html
+/css/css-flexbox/flexbox-overflow-padding-001.html
+/css/css-flexbox/flexbox-overflow-padding-002.html
+/css/css-flexbox/flex-minimum-height-flex-items-025.html
+/css/css-flexbox/flex-minimum-height-flex-items-026.html
+/css/css-flexbox/flex-minimum-height-flex-items-027.html
+/css/css-flexbox/flex-minimum-height-flex-items-028.html
+/css/css-flexbox/flex-minimum-height-flex-items-029.html
+/css/css-flexbox/flex-minimum-height-flex-items-030.html
+/css/css-flexbox/flex-minimum-width-flex-items-015.html
+/css/css-flexbox/flex-minimum-width-flex-items-016.html
+/css/css-flexbox/frameset-crash.html
+/css/css-flexbox/grid-flex-item-006.html
+/css/css-flexbox/justify-content-006.html
+/css/css-flexbox/percentage-descendant-of-anonymous-flex-item.html
+/css/css-flexbox/percentage-max-height-004.html
+/css/css-flexbox/percentage-padding-002.html
+/css/css-flexbox/table-as-item-inflexible-in-column-1.html
+/css/css-flexbox/table-as-item-inflexible-in-column-2.html
+/css/css-flexbox/table-as-item-inflexible-in-row-1.html
+/css/css-flexbox/table-as-item-inflexible-in-row-2.html
+/css/css-flexbox/table-as-item-min-content-height-1.tentative.html
+/css/css-flexbox/table-as-item-min-content-height-2.tentative.html
+/css/css-flexbox/table-as-item-min-height-1.html
+/css/css-flexbox/table-as-item-narrow-content-2.html
+/css/css-flexbox/table-as-item-percent-width-cell-001.html
+/css/css-flexbox/table-as-item-specified-height.html
+/css/css-flexbox/table-as-item-stretch-cross-size-2.html
+/css/css-flexbox/table-as-item-stretch-cross-size-3.html
+/css/css-flexbox/table-as-item-stretch-cross-size-4.html
+/css/css-flexbox/table-as-item-stretch-cross-size-5.html
+/css/css-flexbox/table-item-flex-percentage-min-width.html


### PR DESCRIPTION
The new tests seem reasonable to include, with two hesitations:

 * table-as-item* -- We explicitly decided to exclude tables as a focus area from compat2021. Making Blink pass these `flexbox/table-as-item` tests required a bunch of work in the tables code. Maybe we shouldn't penalize Webkit for an area that we agreed to deprioritize? Maybe we should exclude any of these table tests, including preexisting, that any engine fails?
 * flexbox-min-width-auto-00{5,6} -- Currently all engines pass, but Blink thinks the tests are wrong and plans to change them as long as the behavior change is web compatible (see https://github.com/web-platform-tests/wpt/issues/28805)

@dholbert, thoughts on the updated test list? Any we should remove from the original list because they are invalid?