### PR TITLE
Remove position-sticky test that isn't agreed upon

### DIFF
--- a/compat-2021/position-sticky-tests.txt
+++ b/compat-2021/position-sticky-tests.txt
@@ -63,7 +63,6 @@
 /css/css-position/sticky/position-sticky-get-bounding-client-rect.html
 /css/css-position/sticky/position-sticky-grid.html
 /css/css-position/sticky/position-sticky-inflow-position.html
-/css/css-position/sticky/position-sticky-input-box-gets-focused-after-scroll.html
 /css/css-position/sticky/position-sticky-left.html
 /css/css-position/sticky/position-sticky-margins.html
 /css/css-position/sticky/position-sticky-nested-left.html


### PR DESCRIPTION
position-sticky-input-box-gets-focused-after-scroll.html tests
behaviour that isn't widely agreed upon, as I understand it. The
test passes in Chrome only due to an unshipped feature behind
the `--experimental-web-platform-features` flag, which Chrome
doesn't currently intend to ship either.