### PR TITLE
Run the update GitHub action daily

### DIFF
--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -1,8 +1,8 @@
 name: Update gh-pages
 on:
-  # Trigger on UTC noon on Mon+Wed+Fri, or manually.
+  # Trigger on UTC noon daily, or manually.
   schedule:
-    - cron: '0 12 * * 1,3,5'
+    - cron: '0 12 * * *'
   workflow_dispatch:
 jobs:
   update-gh-pages:


### PR DESCRIPTION
c.f. #63

There's very little reason not to do this on a daily basis; GitHub Actions certainly has the capacity to run this on a daily basis, and it provides more timely results. The only downside is it makes the graph data files bigger, but in reality these are still relatively small files (especially in comparison to other files which wpt.fyi loads).