### PR TITLE
Exclude dates where Safari is showing having zero results

### DIFF
--- a/browser-specific-failures.js
+++ b/browser-specific-failures.js
@@ -42,6 +42,9 @@ const STABLE_BAD_RANGES = [
   [moment('2020-07-08'), moment('2020-07-16')],
   // This was a Firefox outage which produced only partial test results.
   [moment('2020-07-21'), moment('2020-08-15')],
+  // This was a regression from https://github.com/web-platform-tests/wpt/pull/29089,
+  // fixed by https://github.com/web-platform-tests/wpt/pull/32540
+  [moment('2022-01-25'), moment('2022-01-27')],
 ];
 const EXPERIMENTAL_BAD_RANGES = [
   // This was a safaridriver outage, resolved by
@@ -49,6 +52,9 @@ const EXPERIMENTAL_BAD_RANGES = [
   [moment('2019-06-27'), moment('2019-08-23')],
   // This was a general outage due to the Taskcluster Checks migration.
   [moment('2020-07-08'), moment('2020-07-16')],
+  // This was a regression from https://github.com/web-platform-tests/wpt/pull/29089,
+  // fixed by https://github.com/web-platform-tests/wpt/pull/32540
+  [moment('2022-01-25'), moment('2022-01-27')],
 ];
 
 // There have been periods where results cannot be considered valid and

--- a/compat-2021/main.js
+++ b/compat-2021/main.js
@@ -42,6 +42,9 @@ const STABLE_BAD_RANGES = [
   [moment('2020-07-08'), moment('2020-07-16')],
   // This was a Firefox outage which produced only partial test results.
   [moment('2020-07-21'), moment('2020-08-15')],
+  // This was a regression from https://github.com/web-platform-tests/wpt/pull/29089,
+  // fixed by https://github.com/web-platform-tests/wpt/pull/32540
+  [moment('2022-01-25'), moment('2022-01-27')],
 ];
 const EXPERIMENTAL_BAD_RANGES = [
   // This was a safaridriver outage, resolved by
@@ -51,6 +54,9 @@ const EXPERIMENTAL_BAD_RANGES = [
   [moment('2020-07-08'), moment('2020-07-16')],
   // Something went wrong with the Firefox run on this date.
   [moment('2021-03-08'), moment('2021-03-09')],
+  // This was a regression from https://github.com/web-platform-tests/wpt/pull/29089,
+  // fixed by https://github.com/web-platform-tests/wpt/pull/32540
+  [moment('2022-01-25'), moment('2022-01-27')],
 ];
 
 // There have been periods where results cannot be considered valid and


### PR DESCRIPTION
This was a regression from https://github.com/web-platform-tests/wpt/pull/29089, fixed by https://github.com/web-platform-tests/wpt/pull/32540.

![A screenshot of wpt.fyi showing Safari with no results and a dramatic drop-off in the BSF graph](https://user-images.githubusercontent.com/176218/151444223-1e63dfe7-951c-480d-8b5b-9690aabe6aff.png)

I think this also requires a PR to gh-pages (but only after this has landed) to remove the bad data rows.