### PR TITLE
Fix #79: BSF scoring is wrong with case-varying names

### DIFF
--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -45,6 +45,7 @@ class IteratorHelper {
   constructor(arrOrObject, comparatorFunc) {
     this.currentIndex = 0;
     this.values = arrOrObject;
+    this.comparator = comparatorFunc;
 
     if (Array.isArray(this.values)) {
       this.keys = null;
@@ -88,6 +89,7 @@ class IteratorHelper {
 }
 
 function findSmallestNameAndIndex(browserSubtests) {
+  const comparator = browserSubtests[0].comparator;
   let smallestName = null;
   let smallestIdx = null;
   for (let i = 0; i < browserSubtests.length; i++) {
@@ -95,7 +97,7 @@ function findSmallestNameAndIndex(browserSubtests) {
       continue;
     }
     if (smallestName == null ||
-        browserSubtests[i].value().name < smallestName) {
+        comparator(browserSubtests[i].value().name, smallestName) < 0) {
       smallestName = browserSubtests[i].value().name;
       smallestIdx = i;
     }
@@ -289,7 +291,7 @@ function scoreTest(browserTests, testPath, testFilter) {
   if (browserTests.every(t => !t.subtests || t.subtests.length == 0)) {
     scores = scoreTopLevelTest(browserTests);
   } else if (browserTests.every(t => t.subtests && t.subtests.length > 0)) {
-    const comparator = (s1, s2) => s1.name.localeCompare(s2.name);
+    const comparator = (s1, s2) => (s1 > s2) - (s1 < s2);
     scores = scoreSubtests(browserTests.map(
         tests => new IteratorHelper(tests.subtests, comparator)));
   }
@@ -309,7 +311,7 @@ function walkTrees(browserTrees, path, testFilter) {
   let scores = new Array(browserTrees.length).fill(0);
 
   // Sorting comparator to sort Object keys alphabetically.
-  const keyComparator = (k1, k2) => k1.localeCompare(k2);
+  const keyComparator = (k1, k2) => (k1 > k2) - (k1 < k2);
 
   // First deal with any tests that are at this level of the tree.
   const browserTests = browserTrees.map(
@@ -340,7 +342,7 @@ function walkTrees(browserTrees, path, testFilter) {
     let smallestKey = browserTests[0].key();
     let smallestIdx = 0;
     for (let i = 1; i < browserTests.length; i++) {
-      if (browserTests[i].key() < smallestKey) {
+      if (keyComparator(browserTests[i].key(), smallestKey) < 0) {
         smallestKey = browserTests[i].key();
         smallestIdx = i;
       }
@@ -376,7 +378,7 @@ function walkTrees(browserTrees, path, testFilter) {
     let smallestKey = browserSubtrees[0].key();
     let smallestIdx = 0;
     for (let i = 1; i < browserSubtrees.length; i++) {
-      if (browserSubtrees[i].key() < smallestKey) {
+      if (keyComparator(browserSubtrees[i].key(), smallestKey) < 0) {
         smallestKey = browserSubtrees[i].key();
         smallestIdx = i;
       }

--- a/test/browser-specific.js
+++ b/test/browser-specific.js
@@ -458,6 +458,35 @@ describe('browser-specific.js', () => {
       let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers);
       assert.deepEqual(scores, new Map([['chrome', 0], ['firefox', 0]]));
     });
+
+    it('should handle tests that arent in all (three) browsers', () => {
+      const expectedBrowsers = new Set(['chrome', 'firefox', 'safari']);
+
+      let chromeTree = new TreeBuilder()
+          .addTest('TestA', 'OK')
+          .addSubtest('TestA', 'TEST (upper)', 'PASS')
+          .build();
+
+      let firefoxTree = new TreeBuilder()
+          .addTest('TestA', 'OK')
+          .addSubtest('TestA', 'test (lower)', 'PASS')
+          .build();
+
+      let safariTree = new TreeBuilder()
+          .addTest('TestA', 'OK')
+          .addSubtest('TestA', 'TEST (upper)', 'PASS')
+          .addSubtest('TestA', 'test (lower)', 'PASS')
+          .build();
+
+      let runs = [
+          { browser_name: 'chrome', tree: chromeTree },
+          { browser_name: 'firefox', tree: firefoxTree },
+          { browser_name: 'safari', tree: safariTree },
+      ];
+
+      let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers);
+      assert.deepEqual(scores, new Map([['chrome', 0.5], ['firefox', 0.5], ['safari', 0.0]]));
+    });
   });
 
   describe('Filtering Tests', () => {


### PR DESCRIPTION
The important thing to remember is that we need to use the same comparator everywhere; it matters much less what it is than that it is consistent.

Fixes #79.

I don't know quite what we want to do here, given this is in principle a breaking change. It's also potentially not the only one I might find in the near future, so maybe we should hold off a little?