### PR TITLE
Ignore duplicate subtests for BSF

### DIFF
--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -116,6 +116,7 @@ function scoreSubtests(browserSubtests) {
   // browser-specific subtest failures first, then divide by the number of
   // subtests later to get the score (see the note on normalization above).
   let denominator = 0;
+  let prevName = null;
   const counts = new Array(browserSubtests.length).fill(0);
 
   while (browserSubtests.every(subtests => subtests.hasCurrent())) {
@@ -124,64 +125,70 @@ function scoreSubtests(browserSubtests) {
     const [name] = findSmallestNameAndIndex(browserSubtests);
     const onSameSubtest = browserSubtests.filter(s => s.value().name == name);
     if (onSameSubtest.length < browserSubtests.length) {
-      // At this point at least one browser is missing a test that at least one
-      // other browser has. This could be a browser-specific failure, if exactly
-      // N-1 browsers have a passing state for that test (as we are treating
-      // missing as a failure state).
-      denominator += 1;
-      if (onSameSubtest.length == browserSubtests.length - 1) {
-        if (onSameSubtest.every(s => TEST_PASS_STATUSES.includes(
+      if (name !== prevName) {
+        // At this point at least one browser is missing a test that at least one
+        // other browser has. This could be a browser-specific failure, if exactly
+        // N-1 browsers have a passing state for that test (as we are treating
+        // missing as a failure state).
+        denominator += 1;
+        if (onSameSubtest.length == browserSubtests.length - 1) {
+          if (onSameSubtest.every(s => TEST_PASS_STATUSES.includes(
             s.value().status))) {
-          for (let i = 0; i < browserSubtests.length; i++) {
-            if (browserSubtests[i].value().name != name) {
-              counts[i] += 1;
-              break;
+            for (let i = 0; i < browserSubtests.length; i++) {
+              if (browserSubtests[i].value().name != name) {
+                counts[i] += 1;
+                break;
+              }
             }
           }
         }
       }
 
+      prevName = name;
       onSameSubtest.forEach(subtest => subtest.moveNext());
       continue;
     }
 
-    // The iterators are all aligned at the same subtest, so score it!
-    //
-    // NOTE: There actually (rarely) exist distinct subtests with the same name
-    // in the data, usually because of unprintable characters. This can
-    // influence the result as we may mismatch results (i.e. if some browser has
-    // results for one duplicate-named subtest but not another).
-    //
-    // Overall the impact is minor; it at most affects a fraction of a single
-    // test, so less than 1 point of the final score per affected test.
-    denominator += 1;
+    if (name !== prevName) {
+      // The iterators are all aligned at the same subtest, so score it!
+      //
+      // NOTE: There actually (rarely) exist distinct subtests with the same name
+      // in the data, usually because of unprintable characters. This can
+      // influence the result as we may mismatch results (i.e. if some browser has
+      // results for one duplicate-named subtest but not another).
+      //
+      // Overall the impact is minor; it at most affects a fraction of a single
+      // test, so less than 1 point of the final score per affected test.
+      denominator += 1;
 
-    let failed = [];
-    for (let i = 0; i < browserSubtests.length; i++) {
-      const status = browserSubtests[i].value().status;
-      if (!KNOWN_SUBTEST_STATUSES.includes(status)) {
-        throw new Error(`Unknown subtest status for ` +
-            `'${browserSubtests[i].name}': '${status}'`);
+      let failed = [];
+      for (let i = 0; i < browserSubtests.length; i++) {
+        const status = browserSubtests[i].value().status;
+        if (!KNOWN_SUBTEST_STATUSES.includes(status)) {
+          throw new Error(`Unknown subtest status for ` +
+                          `'${browserSubtests[i].name}': '${status}'`);
+        }
+
+        // A 'neutral' subtest status means that a browser has a result which is
+        // not a failure, but which is also not a proper pass (one such example
+        // is SKIP). If any browser has such a status, no browser can be a
+        // browser-specific failure (since we don't know what the 'real' result
+        // for the neutral-status browser would be).
+        if (SUBTEST_NEUTRAL_STATUSES.includes(status)) {
+          failed = [];
+          break;
+        }
+
+        if (SUBTEST_FAIL_STATUSES.includes(status)) {
+          failed.push(i);
+        }
       }
-
-      // A 'neutral' subtest status means that a browser has a result which is
-      // not a failure, but which is also not a proper pass (one such example
-      // is SKIP). If any browser has such a status, no browser can be a
-      // browser-specific failure (since we don't know what the 'real' result
-      // for the neutral-status browser would be).
-      if (SUBTEST_NEUTRAL_STATUSES.includes(status)) {
-        failed = [];
-        break;
-      }
-
-      if (SUBTEST_FAIL_STATUSES.includes(status)) {
-        failed.push(i);
+      if (failed.length == 1) {
+        counts[failed[0]] += 1;
       }
     }
-    if (failed.length == 1) {
-      counts[failed[0]] += 1;
-    }
 
+    prevName = name;
     browserSubtests.forEach(s => s.moveNext());
   }
 
@@ -199,22 +206,25 @@ function scoreSubtests(browserSubtests) {
       throw new Error('Internal error: Previous loop terminated too early');
     }
 
-    // If N-1 browser have this subtest with a pass status, then the one where
-    // it is missing is a browser-specific failure.
-    denominator += 1;
-    if (onSameSubtest.length == browserSubtests.length - 1) {
-      if (onSameSubtest.every(s => TEST_PASS_STATUSES.includes(
+    if (name !== prevName) {
+      // If N-1 browser have this subtest with a pass status, then the one where
+      // it is missing is a browser-specific failure.
+      denominator += 1;
+      if (onSameSubtest.length == browserSubtests.length - 1) {
+        if (onSameSubtest.every(s => TEST_PASS_STATUSES.includes(
           s.value().status))) {
-        for (let i = 0; i < browserSubtests.length; i++) {
-          if (!browserSubtests[i].hasCurrent()) {
-            counts[i] += 1;
-            break;
+          for (let i = 0; i < browserSubtests.length; i++) {
+            if (!browserSubtests[i].hasCurrent()) {
+              counts[i] += 1;
+              break;
+            }
           }
         }
       }
     }
 
     // Move all with the smallest name on.
+    prevName = name;
     onSameSubtest.forEach(subtest => subtest.moveNext());
   }
 


### PR DESCRIPTION
This can happen due to, e.g., https://github.com/web-platform-tests/wpt/issues/12632, and this currently leads to very much surprising scoring.

As with #80, I don't know quite what we want to do here, given this is in principle a breaking change. It's also potentially not the only one I might find in the near future, so maybe we should hold off a little?