### PR TITLE
only skip based on blob id after we know we have the same test

### DIFF
--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -308,17 +308,10 @@ function walkTrees(browserTrees, path, testFilter) {
   // done once we have exhausted all tests from some browser (leftover tests in
   // other browsers don't matter).
   while (browserTests.every(tests => tests.hasCurrent())) {
-    // If the tests are all the same blob (which happens due to the caching in
-    // lib/results.js), we can just skip them; it is impossible for there to be
-    // browser-specific failures.
-    if (browserTests.every(t => t.value() === browserTests[0].value())) {
-      browserTests.forEach(t => t.moveNext());
-      continue;
-    }
-
     // If we are looking at the same test across all browsers, but they aren't
     // the exact same objects, they need to be scored!
-    if (browserTests.every(t => t.key() === browserTests[0].key())) {
+    if (browserTests.every(t => t.key() === browserTests[0].key()) &&
+        !browserTests.every(t => t.value() === browserTests[0].value())) {
       const testPath = path + '/' + browserTests[0].key();
       try {
         const testScores = scoreTest(

--- a/test/browser-specific.js
+++ b/test/browser-specific.js
@@ -316,6 +316,50 @@ describe('browser-specific.js', () => {
       assert.deepEqual(scores, new Map([['chrome', 0], ['firefox', 0]]));
     });
 
+    it('should ignore tests that arent in all browsers, with confusing IDs', () => {
+      const expectedBrowsers = new Set(['chrome', 'firefox']);
+
+      // In the real code, the IDs are from git blob IDs, and thus all identical
+      // statuses have the same ID.
+      const PASS = {
+        "status": "PASS",
+        "id": ++uniqueId
+      };
+
+      const FAIL = {
+        "status": "FAIL",
+        "id": ++uniqueId
+      };
+
+      let chromeTree = {
+        "trees": {},
+        "tests": {
+          "block-end-aligned-abspos-with-overflow.html": PASS
+        },
+        "id": ++uniqueId
+      };
+
+      let firefoxTree = {
+        "trees": {},
+        "tests": {
+          // note that block-002-wm-vrl-print.html and
+          // block-end-aligned-abspos-with-overflow.html above have the same PASS object
+          // for their results
+          "block-002-wm-vrl-print.html": PASS,
+          "block-end-aligned-abspos-with-overflow.html": FAIL
+        },
+        "id": ++uniqueId
+      };
+
+      let runs = [
+          { browser_name: 'chrome', tree: chromeTree },
+          { browser_name: 'firefox', tree: firefoxTree },
+      ];
+
+      let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers);
+      assert.deepEqual(scores, new Map([['chrome', 0], ['firefox', 1]]));
+    });
+
     it('should ignore subtrees that arent in all browsers', () => {
       const expectedBrowsers = new Set(['chrome', 'firefox']);
 


### PR DESCRIPTION
We need to check we have everything aligned before we start skipping based on results.

This causes mis-scoring in https://wpt.fyi/results/css/css-break?sha=fdb441a036fae9246b9f7348778a41e2d233f5c5&label=master&label=experimental&product=chrome&product=firefox&product=safari for example.