### PR TITLE
Add bad range for Firefox

### DIFF
--- a/bad-ranges.js
+++ b/bad-ranges.js
@@ -28,6 +28,8 @@ const EXPERIMENTAL_BAD_RANGES = [
   [moment('2019-06-27'), moment('2019-08-23')],
   // This was a general outage due to the Taskcluster Checks migration.
   [moment('2020-07-08'), moment('2020-07-16')],
+  // Something went wrong with the Firefox run on this date.
+  [moment('2021-03-08'), moment('2021-03-09')],
   // This was a regression from https://github.com/web-platform-tests/wpt/pull/29089,
   // fixed by https://github.com/web-platform-tests/wpt/pull/32540
   [moment('2022-01-25'), moment('2022-01-27')],


### PR DESCRIPTION
This was accidentally dropped as the two copies of bad ranges were out
of sync when they were merged:
https://github.com/Ecosystem-Infra/wpt-results-analysis/commit/e7895da1189891b529e876d019ca4fdcc39f9c3d