### PR TITLE
Revert "Fix #79: BSF scoring is wrong with case-varying names"

### DIFF
--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -45,7 +45,6 @@ class IteratorHelper {
   constructor(arrOrObject, comparatorFunc) {
     this.currentIndex = 0;
     this.values = arrOrObject;
-    this.comparator = comparatorFunc;
 
     if (Array.isArray(this.values)) {
       this.keys = null;
@@ -89,7 +88,6 @@ class IteratorHelper {
 }
 
 function findSmallestNameAndIndex(browserSubtests) {
-  const comparator = browserSubtests[0].comparator;
   let smallestName = null;
   let smallestIdx = null;
   for (let i = 0; i < browserSubtests.length; i++) {
@@ -97,7 +95,7 @@ function findSmallestNameAndIndex(browserSubtests) {
       continue;
     }
     if (smallestName == null ||
-        comparator(browserSubtests[i].value().name, smallestName) < 0) {
+        browserSubtests[i].value().name < smallestName) {
       smallestName = browserSubtests[i].value().name;
       smallestIdx = i;
     }
@@ -291,7 +289,7 @@ function scoreTest(browserTests, testPath, testFilter) {
   if (browserTests.every(t => !t.subtests || t.subtests.length == 0)) {
     scores = scoreTopLevelTest(browserTests);
   } else if (browserTests.every(t => t.subtests && t.subtests.length > 0)) {
-    const comparator = (s1, s2) => (s1 > s2) - (s1 < s2);
+    const comparator = (s1, s2) => s1.name.localeCompare(s2.name);
     scores = scoreSubtests(browserTests.map(
         tests => new IteratorHelper(tests.subtests, comparator)));
   }
@@ -311,7 +309,7 @@ function walkTrees(browserTrees, path, testFilter) {
   let scores = new Array(browserTrees.length).fill(0);
 
   // Sorting comparator to sort Object keys alphabetically.
-  const keyComparator = (k1, k2) => (k1 > k2) - (k1 < k2);
+  const keyComparator = (k1, k2) => k1.localeCompare(k2);
 
   // First deal with any tests that are at this level of the tree.
   const browserTests = browserTrees.map(
@@ -342,7 +340,7 @@ function walkTrees(browserTrees, path, testFilter) {
     let smallestKey = browserTests[0].key();
     let smallestIdx = 0;
     for (let i = 1; i < browserTests.length; i++) {
-      if (keyComparator(browserTests[i].key(), smallestKey) < 0) {
+      if (browserTests[i].key() < smallestKey) {
         smallestKey = browserTests[i].key();
         smallestIdx = i;
       }
@@ -378,7 +376,7 @@ function walkTrees(browserTrees, path, testFilter) {
     let smallestKey = browserSubtrees[0].key();
     let smallestIdx = 0;
     for (let i = 1; i < browserSubtrees.length; i++) {
-      if (keyComparator(browserSubtrees[i].key(), smallestKey) < 0) {
+      if (browserSubtrees[i].key() < smallestKey) {
         smallestKey = browserSubtrees[i].key();
         smallestIdx = i;
       }

--- a/test/browser-specific.js
+++ b/test/browser-specific.js
@@ -458,35 +458,6 @@ describe('browser-specific.js', () => {
       let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers);
       assert.deepEqual(scores, new Map([['chrome', 0], ['firefox', 0]]));
     });
-
-    it('should handle tests that arent in all (three) browsers', () => {
-      const expectedBrowsers = new Set(['chrome', 'firefox', 'safari']);
-
-      let chromeTree = new TreeBuilder()
-          .addTest('TestA', 'OK')
-          .addSubtest('TestA', 'TEST (upper)', 'PASS')
-          .build();
-
-      let firefoxTree = new TreeBuilder()
-          .addTest('TestA', 'OK')
-          .addSubtest('TestA', 'test (lower)', 'PASS')
-          .build();
-
-      let safariTree = new TreeBuilder()
-          .addTest('TestA', 'OK')
-          .addSubtest('TestA', 'TEST (upper)', 'PASS')
-          .addSubtest('TestA', 'test (lower)', 'PASS')
-          .build();
-
-      let runs = [
-          { browser_name: 'chrome', tree: chromeTree },
-          { browser_name: 'firefox', tree: firefoxTree },
-          { browser_name: 'safari', tree: safariTree },
-      ];
-
-      let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers);
-      assert.deepEqual(scores, new Map([['chrome', 0.5], ['firefox', 0.5], ['safari', 0.0]]));
-    });
   });
 
   describe('Filtering Tests', () => {


### PR DESCRIPTION
Reverts Ecosystem-Infra/wpt-results-analysis#80

See https://github.com/Ecosystem-Infra/wpt-results-analysis/pull/92#issuecomment-1048946826

Some of the later changes seem to have made this clearly wrong, e.g. https://wpt.fyi/results/fetch/metadata/window-open.https.sub.html?sha=fdb441a036&label=master&label=experimental&max-count=1&product=chrome&product=firefox&product=safari getting scored as having Chrome BSFs.