### PR TITLE
Retry fixing #79: scoring is wrong with case-varying names

### DIFF
--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -90,20 +90,20 @@ class IteratorHelper {
 
 function findSmallestNameAndIndex(browserSubtests) {
   const comparator = browserSubtests[0].comparator;
-  let smallestName = null;
+  let smallest = null;
   let smallestIdx = null;
   for (let i = 0; i < browserSubtests.length; i++) {
     if (!browserSubtests[i].hasCurrent()) {
       continue;
     }
-    if (smallestName == null ||
-        comparator(browserSubtests[i].value().name, smallestName) < 0) {
-      smallestName = browserSubtests[i].value().name;
+    if (smallest == null ||
+        comparator(browserSubtests[i].value(), smallest) < 0) {
+      smallest = browserSubtests[i].value();
       smallestIdx = i;
     }
   }
 
-  return [smallestName, smallestIdx];
+  return [smallest.name, smallestIdx];
 }
 
 // Scores a WPT test that contains subtests, returning an array of scores for
@@ -291,7 +291,7 @@ function scoreTest(browserTests, testPath, testFilter) {
   if (browserTests.every(t => !t.subtests || t.subtests.length == 0)) {
     scores = scoreTopLevelTest(browserTests);
   } else if (browserTests.every(t => t.subtests && t.subtests.length > 0)) {
-    const comparator = (s1, s2) => (s1 > s2) - (s1 < s2);
+    const comparator = (s1, s2) => (s1.name > s2.name) - (s1.name < s2.name);
     scores = scoreSubtests(browserTests.map(
         tests => new IteratorHelper(tests.subtests, comparator)));
   }

--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -45,6 +45,7 @@ class IteratorHelper {
   constructor(arrOrObject, comparatorFunc) {
     this.currentIndex = 0;
     this.values = arrOrObject;
+    this.comparator = comparatorFunc;
 
     if (Array.isArray(this.values)) {
       this.keys = null;
@@ -88,6 +89,7 @@ class IteratorHelper {
 }
 
 function findSmallestNameAndIndex(browserSubtests) {
+  const comparator = browserSubtests[0].comparator;
   let smallestName = null;
   let smallestIdx = null;
   for (let i = 0; i < browserSubtests.length; i++) {
@@ -95,7 +97,7 @@ function findSmallestNameAndIndex(browserSubtests) {
       continue;
     }
     if (smallestName == null ||
-        browserSubtests[i].value().name < smallestName) {
+        comparator(browserSubtests[i].value().name, smallestName) < 0) {
       smallestName = browserSubtests[i].value().name;
       smallestIdx = i;
     }
@@ -289,7 +291,7 @@ function scoreTest(browserTests, testPath, testFilter) {
   if (browserTests.every(t => !t.subtests || t.subtests.length == 0)) {
     scores = scoreTopLevelTest(browserTests);
   } else if (browserTests.every(t => t.subtests && t.subtests.length > 0)) {
-    const comparator = (s1, s2) => s1.name.localeCompare(s2.name);
+    const comparator = (s1, s2) => (s1 > s2) - (s1 < s2);
     scores = scoreSubtests(browserTests.map(
         tests => new IteratorHelper(tests.subtests, comparator)));
   }
@@ -309,7 +311,7 @@ function walkTrees(browserTrees, path, testFilter) {
   let scores = new Array(browserTrees.length).fill(0);
 
   // Sorting comparator to sort Object keys alphabetically.
-  const keyComparator = (k1, k2) => k1.localeCompare(k2);
+  const keyComparator = (k1, k2) => (k1 > k2) - (k1 < k2);
 
   // First deal with any tests that are at this level of the tree.
   const browserTests = browserTrees.map(
@@ -340,7 +342,7 @@ function walkTrees(browserTrees, path, testFilter) {
     let smallestKey = browserTests[0].key();
     let smallestIdx = 0;
     for (let i = 1; i < browserTests.length; i++) {
-      if (browserTests[i].key() < smallestKey) {
+      if (keyComparator(browserTests[i].key(), smallestKey) < 0) {
         smallestKey = browserTests[i].key();
         smallestIdx = i;
       }
@@ -376,7 +378,7 @@ function walkTrees(browserTrees, path, testFilter) {
     let smallestKey = browserSubtrees[0].key();
     let smallestIdx = 0;
     for (let i = 1; i < browserSubtrees.length; i++) {
-      if (browserSubtrees[i].key() < smallestKey) {
+      if (keyComparator(browserSubtrees[i].key(), smallestKey) < 0) {
         smallestKey = browserSubtrees[i].key();
         smallestIdx = i;
       }

--- a/test/browser-specific.js
+++ b/test/browser-specific.js
@@ -458,6 +458,35 @@ describe('browser-specific.js', () => {
       let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers);
       assert.deepEqual(scores, new Map([['chrome', 0], ['firefox', 0]]));
     });
+
+    it('should handle tests that arent in all (three) browsers', () => {
+      const expectedBrowsers = new Set(['chrome', 'firefox', 'safari']);
+
+      let chromeTree = new TreeBuilder()
+          .addTest('TestA', 'OK')
+          .addSubtest('TestA', 'TEST (upper)', 'PASS')
+          .build();
+
+      let firefoxTree = new TreeBuilder()
+          .addTest('TestA', 'OK')
+          .addSubtest('TestA', 'test (lower)', 'PASS')
+          .build();
+
+      let safariTree = new TreeBuilder()
+          .addTest('TestA', 'OK')
+          .addSubtest('TestA', 'TEST (upper)', 'PASS')
+          .addSubtest('TestA', 'test (lower)', 'PASS')
+          .build();
+
+      let runs = [
+          { browser_name: 'chrome', tree: chromeTree },
+          { browser_name: 'firefox', tree: firefoxTree },
+          { browser_name: 'safari', tree: safariTree },
+      ];
+
+      let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers);
+      assert.deepEqual(scores, new Map([['chrome', 0.5], ['firefox', 0.5], ['safari', 0.0]]));
+    });
   });
 
   describe('Filtering Tests', () => {

--- a/test/browser-specific.js
+++ b/test/browser-specific.js
@@ -459,7 +459,33 @@ describe('browser-specific.js', () => {
       assert.deepEqual(scores, new Map([['chrome', 0], ['firefox', 0]]));
     });
 
-    it('should handle tests that arent in all (three) browsers', () => {
+    it('should handle tests differing by case', () => {
+      const expectedBrowsers = new Set(['chrome', 'firefox', 'safari']);
+
+      let chromeTree = new TreeBuilder()
+          .addTest('TEST (upper)', 'FAIL')
+          .addTest('test (lower)', 'PASS')
+          .build();
+
+      let firefoxTree = new TreeBuilder()
+          .addTest('TEST (upper)', 'PASS')
+          .build();
+
+      let safariTree = new TreeBuilder()
+          .addTest('TEST (upper)', 'PASS')
+          .build();
+
+      let runs = [
+          { browser_name: 'chrome', tree: chromeTree },
+          { browser_name: 'firefox', tree: firefoxTree },
+          { browser_name: 'safari', tree: safariTree },
+      ];
+
+      let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers);
+      assert.deepEqual(scores, new Map([['chrome', 1], ['firefox', 0], ['safari', 0]]));
+    });
+
+    it('should handle subtests differing by case', () => {
       const expectedBrowsers = new Set(['chrome', 'firefox', 'safari']);
 
       let chromeTree = new TreeBuilder()
@@ -476,6 +502,35 @@ describe('browser-specific.js', () => {
           .addTest('TestA', 'OK')
           .addSubtest('TestA', 'TEST (upper)', 'PASS')
           .addSubtest('TestA', 'test (lower)', 'PASS')
+          .build();
+
+      let runs = [
+          { browser_name: 'chrome', tree: chromeTree },
+          { browser_name: 'firefox', tree: firefoxTree },
+          { browser_name: 'safari', tree: safariTree },
+      ];
+
+      let scores = browserSpecific.scoreBrowserSpecificFailures(runs, expectedBrowsers);
+      assert.deepEqual(scores, new Map([['chrome', 0.5], ['firefox', 0.5], ['safari', 0.0]]));
+    });
+
+    it('should handle subtests differing by case 2', () => {
+      const expectedBrowsers = new Set(['chrome', 'firefox', 'safari']);
+
+      let chromeTree = new TreeBuilder()
+          .addTest('TestA', 'OK')
+          .addSubtest('TestA', 'TEST (upper)', 'PASS')
+          .build();
+
+      let firefoxTree = new TreeBuilder()
+          .addTest('TestA', 'OK')
+          .addSubtest('TestA', 'test (lower)', 'PASS')
+          .build();
+
+      let safariTree = new TreeBuilder()
+          .addTest('TestA', 'OK')
+          .addSubtest('TestA', 'test (lower)', 'PASS')
+          .addSubtest('TestA', 'TEST (upper)', 'PASS')
           .build();
 
       let runs = [


### PR DESCRIPTION
Fixes #79 (for real this time).

Draft because I need to write way more tests for this.

So, the big scoring jump that I wasn't expecting is because my [original analysis of the scores](https://github.com/Ecosystem-Infra/wpt-results-analysis/pull/80#issuecomment-1036405727) was before later changes which extended this from subtests to tests as well. And it turns out there significant numbers of tests we weren't previously scoring (eek!).